### PR TITLE
fix: timeLeftSeconds is nil when the auction is for a WoW token.

### DIFF
--- a/Tracking/AuctionCacheRetail.lua
+++ b/Tracking/AuctionCacheRetail.lua
@@ -154,7 +154,7 @@ end
 
 function SyndicatorAuctionCacheMixin:AddAuction(auctionInfo, itemCount)
   local item = ConvertAuctionInfoToItem(auctionInfo, itemCount)
-  item.expirationTime = time() + auctionInfo.timeLeftSeconds
+  item.expirationTime = auctionInfo.timeLeftSeconds and (time() + auctionInfo.timeLeftSeconds) or nil
   item.auctionID = auctionInfo.auctionID
   table.insert(
     SYNDICATOR_DATA.Characters[self.currentCharacter].auctions,


### PR DESCRIPTION
This was causing an infinite loop of errors when opening the auction house with an active WoW token auction.