### PR TITLE
Add TSM Groups Search (via prefix)

### DIFF
--- a/Search/CheckItem.lua
+++ b/Search/CheckItem.lua
@@ -1666,9 +1666,10 @@ local function GetTSMGroup(details)
     C_Item.RequestLoadItemDataByID(details.itemID)
     return
   end
-  
+
+  local tsmItemString = TSM_API.ToItemString(details.itemLink)
   -- Ungrouped items return nil, invalid item strings raise an error.
-  local group = TSM_API.GetGroupPathByItem(TSM_API.ToItemString(details.itemLink))
+  local group = tsmItemString and TSM_API.GetGroupPathByItem(tsmItemString)
   details.TSMGroup = group and group:lower() or false
   return details.TSMGroup ~= false
 end


### PR DESCRIPTION
### Summary

Thia adds the special search prefix `tsm:` for string searches in TSM groups or group paths. 

Example:

TSM group path of an item: ``Pets`L25`10000-20000``
Any of these should match: `tsm:pets`, `tsm:l25`, ``tsm:pets`l25``, `tsm:-20000`, `tsm:000`, etc.

The path separator is the backtick (grave accent), as used natively in TSM group paths. Alternatively, `->` can be used, which is the separator used by TSM for the tooltip display of a group path (e.g. `tsm:pets->l25`). Remove the `->` gsub, if you think it impacts performance too much (line 1677).

`tsm:` alone matches items that are in any TSM group. So `!tsm:` can be used to highlight all ungrouped items.

### Why?

Baganator has already an *Auto* Category for TSM groups. But this is all-or-nothing, so I (personally) don’t have a use case for it. I use TSM only on my AH toons, and due to pricing needs, the TSM groups there are very fine-grained, which would result in a gazillion of bag categories.

My proposed `tsm:` search acts just like a normal custom search, i.e., it can be used for the bag search, the “everywhere” search, and for defining a category, stand-alone or in combination with other searches, like e.g. `#pet&25&tsm:10000-&#rare`.

### Caveats

This is only tested for a few days, so **there may be glitches or bugs** that have not surfaced yet. There *will* be glitches when searching for groups with characters that are treated a special characters by Syndicator (e.g. the operators), so the search string or group names must not contain these.

### Room for improvement/polishing

This is a basic implementation. **I have not added any GUI components** (in-game help, category builder dropdown, …), as I don’t know if you or the users are even interested in this addition.

However, in my (few) tests it integrates fine with the existing system, since the GUI category builder sees it just as a regular custom search.

One could also simplify it by adding the TSM groups as search scope to the regular search, so that a custom search always also checks the TSM groups. However, I prefer to keep it separate (with the prefix).

### Note on caching

I noticed that for the live search in the char bags, the group paths seem to get cached at first bag open, so that a changed group name in TSM is only reliably reflected after a reload. But this is not the case for the “everywhere” search and for categories. Not sure if these different caching behaviors are intentional or not.
