### PR TITLE
Fix access to ItemVersion lookup structure

### DIFF
--- a/Search/Utilities.lua
+++ b/Search/Utilities.lua
@@ -16,7 +16,7 @@ function addonTable.Search.GetExpansionInfo(itemID)
   if ItemVersion and ItemVersion.API.GetItemVersion then
     local itemVersionDetails = ItemVersion.API.GetItemVersion(itemID, true)
     if itemVersionDetails then
-      return itemVersionDetails.major
+      return itemVersionDetails.expansion.major
     end
   end
   if ATTC and ATTC.SearchForField then


### PR DESCRIPTION
Hi there,

I'm the author of ItemVersion.

First of all, I apologize for not coordinating with you about the breaking change. I just spent some much needed time overhauling the addon over the past week. I did not know (or did not remember) that Baganator/Syndicator were consumers.

One of the results of the overhaul is that this function did not need colon syntax, which you have **already** fixed in 760fea2ed4eab08679a4e04a8eda386fcba4cdf4.

But another result is that [the `major` number that you use is now under the `expansion` key](https://github.com/t-mart/ItemVersion/blob/ab2dbe017367106b8657763d979aff115bb8bf6e/ItemVersion/API.lua#L8-L67), which I fix in this pull request.

The way you have it now with `itemVersionDetails.major`, that will always be `nil`. It needs to be `itemVersionDetails.expansion.major`.

I'm going to load this change in a client now and test it, but I'm certain this change needs to happen.